### PR TITLE
feat: Add Open Graph metadata for SABS page to enhance social sharing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
       {
         url: "https://nathan.bonnell.fr/img/pp.webp",
         width: 1200,
-        height: 630,
+        height: 1200,
         alt: "Portfolio - Nathan Bonnell",
       },
     ],

--- a/src/app/sabs/layout.tsx
+++ b/src/app/sabs/layout.tsx
@@ -8,6 +8,20 @@ export const metadata: Metadata = {
     icons: {
         icon: Logo.src,
     },
+    openGraph: {
+        type: "website",
+        url: "https://nathan.bonnell.fr/sabs",
+        title: "SABS - Page d'accueil",
+        description: "Page d'accueil du site SABS, le site de l'association SABS.",
+        images: [
+            {
+                url: "https://nathan.bonnell.fr/img/sabs/sabs-logo.png",
+                width: 1200,
+                height: 1200,
+                alt: "SABS - Page d'accueil",
+            },
+        ],
+    },
 }
 
 export default async function RootLayout({


### PR DESCRIPTION
This pull request updates metadata configurations for two layouts in the project. The changes primarily focus on modifying image dimensions and adding Open Graph metadata for better social media and search engine optimization.

Metadata updates:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L32-R32): Changed the `height` property of an image in the metadata from `630` to `1200` to match the width and improve image aspect ratio consistency.
* [`src/app/sabs/layout.tsx`](diffhunk://#diff-1d55c131127292f321e78b8fff6f2c353f5d40aea48037d4fba3103a0a6eafb5R11-R24): Added Open Graph metadata, including `type`, `url`, `title`, `description`, and an image object, to enhance social sharing and SEO for the SABS homepage.